### PR TITLE
metrics: add prometheus and basic metrics

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
   lint_test:
     uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.7.0
     with:
+      go-version: "1.23.8"
       run-build: true
       run-unit-tests: true
       run-check-mock-gen: true

--- a/cmd/opfgd/start.go
+++ b/cmd/opfgd/start.go
@@ -13,6 +13,7 @@ import (
 	"github.com/babylonlabs-io/finality-gadget/db"
 	"github.com/babylonlabs-io/finality-gadget/finalitygadget"
 	"github.com/babylonlabs-io/finality-gadget/log"
+	"github.com/babylonlabs-io/finality-gadget/metrics"
 	"github.com/babylonlabs-io/finality-gadget/server"
 	sig "github.com/lightningnetwork/lnd/signal"
 )
@@ -54,6 +55,9 @@ func runStartCmd(ctx client.Context, cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create logger: %w", err)
 	}
+
+	// Initialize metrics
+	metrics.Init(logger)
 
 	// Init local DB for storing and querying blocks
 	db, err := db.NewBBoltHandler(cfg.DBFilePath, logger)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,53 @@
+# Finality Gadget Metrics
+
+This document describes the Prometheus metrics exposed by the finality gadget service.
+
+## Endpoint
+
+Metrics are exposed at `/metrics` on the HTTP server.
+
+## Metrics
+
+### finality_gadget_finalized_blocks_total
+- **Type**: Counter
+- **Description**: Total number of finalized blocks processed by the finality gadget
+- **Labels**: None
+- **Usage**: Track overall finalization progress and rate
+
+### finality_gadget_latest_finalized_block_height
+- **Type**: Gauge  
+- **Description**: Height of the latest block confirmed as finalized by QueryIsBlockBabylonFinalizedFromBabylon
+- **Labels**: None
+- **Usage**: Monitor current finalization status and detect stalls
+
+### finality_gadget_fp_latest_block_voted
+- **Type**: Gauge
+- **Description**: Latest block height that each finality provider voted on
+- **Labels**: 
+  - `fp_pubkey`: Finality provider BTC public key (hex)
+- **Usage**: Track individual FP participation and detect lagging providers
+
+### finality_gadget_block_voters
+- **Type**: Gauge
+- **Description**: List of finality providers who voted for each block
+- **Labels**:
+  - `block_height`: Block height
+  - `fp_pubkeys`: Comma-separated list of FP public keys who voted
+- **Value**: Number of FPs who voted for this block
+- **Usage**: Analyze voting patterns and block-by-block participation
+
+### finality_gadget_fp_voting_power_per_block
+- **Type**: Gauge
+- **Description**: Voting power of each finality provider at each block height
+- **Labels**:
+  - `block_height`: Block height
+  - `fp_pubkey`: Finality provider BTC public key (hex)
+- **Value**: Voting power in satoshis (total BTC delegations)
+- **Usage**: Track voting power distribution and changes over time
+
+## Notes
+
+- Voting power is measured in satoshis (1e8 satoshis = 1 BTC)
+- FP public keys are BTC public keys in hexadecimal format
+- Block heights correspond to L2 chain blocks
+- Metrics are updated in real-time as blocks are processed and finalized 

--- a/finalitygadget/expected_clients.go
+++ b/finalitygadget/expected_clients.go
@@ -20,7 +20,6 @@ type IBitcoinClient interface {
 
 type IBabylonClient interface {
 	QueryAllFpBtcPubKeys(consumerId string) ([]string, error)
-	QueryFpPower(fpPubkeyHex string, btcHeight uint32) (uint64, error)
 	QueryMultiFpPower(fpPubkeyHexList []string, btcHeight uint32) (map[string]uint64, error)
 	QueryEarliestActiveDelBtcHeight(fpPubkeyHexList []string) (uint32, error)
 }

--- a/finalitygadget/finalitygadget.go
+++ b/finalitygadget/finalitygadget.go
@@ -19,6 +19,7 @@ import (
 	"github.com/babylonlabs-io/finality-gadget/cwclient"
 	"github.com/babylonlabs-io/finality-gadget/db"
 	"github.com/babylonlabs-io/finality-gadget/ethl2client"
+	"github.com/babylonlabs-io/finality-gadget/metrics"
 	"github.com/babylonlabs-io/finality-gadget/testutil/mocks"
 	"github.com/babylonlabs-io/finality-gadget/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -542,6 +543,9 @@ func (fg *FinalityGadget) insertBlocks(blocks []*types.Block) error {
 	if err := fg.db.InsertBlocks(normalizedBlocks); err != nil {
 		return fmt.Errorf("failed to batch insert blocks: %w", err)
 	}
+
+	// Increment metrics for finalized blocks
+	metrics.FinalizedBlocksTotal.Add(float64(len(normalizedBlocks)))
 
 	return nil
 }

--- a/finalitygadget/finalitygadget_test.go
+++ b/finalitygadget/finalitygadget_test.go
@@ -35,94 +35,76 @@ func TestQueryIsBlockBabylonFinalized(t *testing.T) {
 	const BTCHeight = uint32(111)
 
 	testCases := []struct {
-		name                    string
-		expectedErr             error
-		block                   *types.Block
-		allFpPks                []string
-		fpPowers                map[string]uint64
-		votedProviders          []string
-		stakingActivationHeight uint32
-		expectResult            bool
+		name           string
+		expectedErr    error
+		block          *types.Block
+		allFpPks       []string
+		fpPowers       map[string]uint64
+		votedProviders []string
+		expectResult   bool
 	}{
 		{
-			name:                    "0% votes, expects false",
-			block:                   &blockWithHashTrimmed,
-			allFpPks:                []string{"pk1", "pk2"},
-			fpPowers:                map[string]uint64{"pk1": 100, "pk2": 300},
-			votedProviders:          []string{},
-			stakingActivationHeight: BTCHeight - 1,
-			expectResult:            false,
-			expectedErr:             nil,
+			name:           "0% votes, expects false",
+			block:          &blockWithHashTrimmed,
+			allFpPks:       []string{"pk1", "pk2"},
+			fpPowers:       map[string]uint64{"pk1": 100, "pk2": 300},
+			votedProviders: []string{},
+			expectResult:   false,
+			expectedErr:    nil,
 		},
 		{
-			name:                    "25% votes, expects false",
-			block:                   &blockWithHashTrimmed,
-			allFpPks:                []string{"pk1", "pk2"},
-			fpPowers:                map[string]uint64{"pk1": 100, "pk2": 300},
-			votedProviders:          []string{"pk1"},
-			stakingActivationHeight: BTCHeight - 1,
-			expectResult:            false,
-			expectedErr:             nil,
+			name:           "25% votes, expects false",
+			block:          &blockWithHashTrimmed,
+			allFpPks:       []string{"pk1", "pk2"},
+			fpPowers:       map[string]uint64{"pk1": 100, "pk2": 300},
+			votedProviders: []string{"pk1"},
+			expectResult:   false,
+			expectedErr:    nil,
 		},
 		{
-			name:                    "exact 2/3 votes, expects true",
-			block:                   &blockWithHashTrimmed,
-			allFpPks:                []string{"pk1", "pk2", "pk3"},
-			fpPowers:                map[string]uint64{"pk1": 100, "pk2": 100, "pk3": 100},
-			votedProviders:          []string{"pk1", "pk2"},
-			stakingActivationHeight: BTCHeight - 1,
-			expectResult:            true,
-			expectedErr:             nil,
+			name:           "exact 2/3 votes, expects true",
+			block:          &blockWithHashTrimmed,
+			allFpPks:       []string{"pk1", "pk2", "pk3"},
+			fpPowers:       map[string]uint64{"pk1": 100, "pk2": 100, "pk3": 100},
+			votedProviders: []string{"pk1", "pk2"},
+			expectResult:   true,
+			expectedErr:    nil,
 		},
 		{
-			name:                    "75% votes, expects true",
-			block:                   &blockWithHashTrimmed,
-			allFpPks:                []string{"pk1", "pk2"},
-			fpPowers:                map[string]uint64{"pk1": 100, "pk2": 300},
-			votedProviders:          []string{"pk2"},
-			stakingActivationHeight: BTCHeight - 1,
-			expectResult:            true,
-			expectedErr:             nil,
+			name:           "75% votes, expects true",
+			block:          &blockWithHashTrimmed,
+			allFpPks:       []string{"pk1", "pk2"},
+			fpPowers:       map[string]uint64{"pk1": 100, "pk2": 300},
+			votedProviders: []string{"pk2"},
+			expectResult:   true,
+			expectedErr:    nil,
 		},
 		{
-			name:                    "100% votes, expects true",
-			block:                   &blockWithHashTrimmed,
-			allFpPks:                []string{"pk1", "pk2", "pk3"},
-			fpPowers:                map[string]uint64{"pk1": 100, "pk2": 100, "pk3": 100},
-			votedProviders:          []string{"pk1", "pk2", "pk3"},
-			stakingActivationHeight: BTCHeight - 1,
-			expectResult:            true,
-			expectedErr:             nil,
+			name:           "100% votes, expects true",
+			block:          &blockWithHashTrimmed,
+			allFpPks:       []string{"pk1", "pk2", "pk3"},
+			fpPowers:       map[string]uint64{"pk1": 100, "pk2": 100, "pk3": 100},
+			votedProviders: []string{"pk1", "pk2", "pk3"},
+			expectResult:   true,
+			expectedErr:    nil,
 		},
 		{
-			name:                    "untrimmed block hash in input params, 75% votes, expects true",
-			block:                   &blockWithHashUntrimmed,
-			allFpPks:                []string{"pk1", "pk2", "pk3", "pk4"},
-			fpPowers:                map[string]uint64{"pk1": 100, "pk2": 100, "pk3": 100, "pk4": 100},
-			votedProviders:          []string{"pk1", "pk2", "pk3"},
-			stakingActivationHeight: BTCHeight - 1,
-			expectResult:            true,
-			expectedErr:             nil,
+			name:           "untrimmed block hash in input params, 75% votes, expects true",
+			block:          &blockWithHashUntrimmed,
+			allFpPks:       []string{"pk1", "pk2", "pk3", "pk4"},
+			fpPowers:       map[string]uint64{"pk1": 100, "pk2": 100, "pk3": 100, "pk4": 100},
+			votedProviders: []string{"pk1", "pk2", "pk3"},
+			expectResult:   true,
+			expectedErr:    nil,
 		},
 		{
-			name:                    "zero voting power, 100% votes, expects false",
-			block:                   &blockWithHashUntrimmed,
-			allFpPks:                []string{"pk1", "pk2", "pk3"},
-			fpPowers:                map[string]uint64{"pk1": 0, "pk2": 0, "pk3": 0},
-			votedProviders:          []string{"pk1", "pk2", "pk3"},
-			stakingActivationHeight: BTCHeight - 1,
-			expectResult:            false,
-			expectedErr:             types.ErrNoFpHasVotingPower,
-		},
-		{
-			name:                    "Btc staking not activated, 100% votes, expects false",
-			block:                   &blockWithHashUntrimmed,
-			allFpPks:                []string{"pk1", "pk2", "pk3"},
-			fpPowers:                map[string]uint64{"pk1": 100, "pk2": 100, "pk3": 100},
-			votedProviders:          []string{"pk1", "pk2", "pk3"},
-			stakingActivationHeight: BTCHeight + 1,
-			expectResult:            false,
-			expectedErr:             types.ErrBtcStakingNotActivated,
+			name:           "zero voting power, 100% votes, expects false",
+			block:          &blockWithHashUntrimmed,
+			allFpPks:       []string{"pk1", "pk2", "pk3"},
+			fpPowers:       map[string]uint64{"pk1": 0, "pk2": 0, "pk3": 0},
+			votedProviders: []string{"pk1", "pk2", "pk3"},
+			expectResult:   false,
+			expectedErr:    types.ErrNoFpHasVotingPower,
 		},
 	}
 
@@ -144,23 +126,17 @@ func TestQueryIsBlockBabylonFinalized(t *testing.T) {
 				QueryAllFpBtcPubKeys(consumerChainID).
 				Return(tc.allFpPks, nil).
 				Times(1)
+
 			mockBBNClient.EXPECT().
-				QueryEarliestActiveDelBtcHeight(tc.allFpPks).
-				Return(tc.stakingActivationHeight, nil).
+				QueryMultiFpPower(tc.allFpPks, BTCHeight).
+				Return(tc.fpPowers, nil).
 				Times(1)
 
-			if !errors.Is(tc.expectedErr, types.ErrBtcStakingNotActivated) {
-				mockBBNClient.EXPECT().
-					QueryMultiFpPower(tc.allFpPks, BTCHeight).
-					Return(tc.fpPowers, nil).
+			if !errors.Is(tc.expectedErr, types.ErrNoFpHasVotingPower) {
+				mockCwClient.EXPECT().
+					QueryListOfVotedFinalityProviders(&blockWithHashTrimmed).
+					Return(tc.votedProviders, tc.expectedErr).
 					Times(1)
-
-				if !errors.Is(tc.expectedErr, types.ErrNoFpHasVotingPower) {
-					mockCwClient.EXPECT().
-						QueryListOfVotedFinalityProviders(&blockWithHashTrimmed).
-						Return(tc.votedProviders, tc.expectedErr).
-						Times(1)
-				}
 			}
 
 			mockFinalityGadget := &FinalityGadget{

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/ethereum/go-ethereum v1.15.10
 	github.com/jsternberg/zap-logfmt v1.3.0
 	github.com/lightningnetwork/lnd v0.16.4-beta.rc1
+	github.com/prometheus/client_golang v1.22.0
 	github.com/rs/cors v1.11.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
@@ -216,7 +217,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.63.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/babylonlabs-io/finality-gadget
 
 go 1.23.8
 
-toolchain go1.23.11
-
 require (
 	github.com/CosmWasm/wasmd v0.55.1
 	github.com/avast/retry-go/v4 v4.5.1

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -25,11 +25,11 @@ var (
 		Help: "List of finality providers who voted for each block",
 	}, []string{"block_height", "fp_pubkeys"})
 
-	// FpVotingPowerPerBlock tracks each FP's voting power at each block
-	FpVotingPowerPerBlock = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "finality_gadget_fp_voting_power_per_block",
-		Help: "Voting power of each finality provider at each block height",
-	}, []string{"block_height", "fp_pubkey"})
+	// FpLatestVotingPower tracks each FP's voting power for the latest processed block
+	FpLatestVotingPower = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "finality_gadget_fp_latest_voting_power",
+		Help: "Latest voting power of each finality provider",
+	}, []string{"fp_pubkey"})
 
 	// LatestFinalizedBlockHeight tracks the height of the latest finalized block
 	LatestFinalizedBlockHeight = promauto.NewGauge(prometheus.GaugeOpts{
@@ -45,6 +45,6 @@ func Init(logger *zap.Logger) {
 		zap.String("blocks_metric", "finality_gadget_finalized_blocks_total"),
 		zap.String("fp_voting_metric", "finality_gadget_fp_latest_block_voted"),
 		zap.String("block_voters_metric", "finality_gadget_block_voters"),
-		zap.String("fp_voting_power_metric", "finality_gadget_fp_voting_power_per_block"),
+		zap.String("fp_voting_power_metric", "finality_gadget_fp_latest_voting_power"),
 		zap.String("latest_finalized_metric", "finality_gadget_latest_finalized_block_height"))
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -12,10 +12,39 @@ var (
 		Name: "finality_gadget_finalized_blocks_total",
 		Help: "The total number of finalized blocks processed by the finality gadget",
 	})
+
+	// FpLatestBlockVoted tracks the latest block height each FP voted on
+	FpLatestBlockVoted = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "finality_gadget_fp_latest_block_voted",
+		Help: "Latest block height that each finality provider voted on",
+	}, []string{"fp_pubkey"})
+
+	// BlockVoters tracks which FPs voted for each block
+	BlockVoters = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "finality_gadget_block_voters",
+		Help: "List of finality providers who voted for each block",
+	}, []string{"block_height", "fp_pubkeys"})
+
+	// FpVotingPowerPerBlock tracks each FP's voting power at each block
+	FpVotingPowerPerBlock = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "finality_gadget_fp_voting_power_per_block",
+		Help: "Voting power of each finality provider at each block height",
+	}, []string{"block_height", "fp_pubkey"})
+
+	// LatestFinalizedBlockHeight tracks the height of the latest finalized block
+	LatestFinalizedBlockHeight = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "finality_gadget_latest_finalized_block_height",
+		Help: "Height of the latest finalized block",
+	})
 )
 
 // Init initializes the metrics registry
 func Init(logger *zap.Logger) {
 	// Metrics are automatically registered via promauto
-	logger.Info("Prometheus metrics initialized", zap.String("metric", "finality_gadget_finalized_blocks_total"))
+	logger.Info("Prometheus metrics initialized",
+		zap.String("blocks_metric", "finality_gadget_finalized_blocks_total"),
+		zap.String("fp_voting_metric", "finality_gadget_fp_latest_block_voted"),
+		zap.String("block_voters_metric", "finality_gadget_block_voters"),
+		zap.String("fp_voting_power_metric", "finality_gadget_fp_voting_power_per_block"),
+		zap.String("latest_finalized_metric", "finality_gadget_latest_finalized_block_height"))
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,21 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.uber.org/zap"
+)
+
+var (
+	// FinalizedBlocksTotal tracks the total number of finalized blocks processed
+	FinalizedBlocksTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "finality_gadget_finalized_blocks_total",
+		Help: "The total number of finalized blocks processed by the finality gadget",
+	})
+)
+
+// Init initializes the metrics registry
+func Init(logger *zap.Logger) {
+	// Metrics are automatically registered via promauto
+	logger.Info("Prometheus metrics initialized", zap.String("metric", "finality_gadget_finalized_blocks_total"))
+}

--- a/server/httpserver.go
+++ b/server/httpserver.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
 )
 
@@ -12,6 +13,7 @@ func (s *Server) newHttpHandler() http.Handler {
 	mux.HandleFunc("/v1/transaction", s.txStatusHandler)
 	mux.HandleFunc("/v1/chainSyncStatus", s.chainSyncStatusHandler)
 	mux.HandleFunc("/health", s.healthHandler)
+	mux.Handle("/metrics", promhttp.Handler())
 	return mux
 }
 

--- a/testutil/mocks/expected_clients_mock.go
+++ b/testutil/mocks/expected_clients_mock.go
@@ -174,21 +174,6 @@ func (mr *MockIBabylonClientMockRecorder) QueryEarliestActiveDelBtcHeight(fpPubk
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryEarliestActiveDelBtcHeight", reflect.TypeOf((*MockIBabylonClient)(nil).QueryEarliestActiveDelBtcHeight), fpPubkeyHexList)
 }
 
-// QueryFpPower mocks base method.
-func (m *MockIBabylonClient) QueryFpPower(fpPubkeyHex string, btcHeight uint32) (uint64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueryFpPower", fpPubkeyHex, btcHeight)
-	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// QueryFpPower indicates an expected call of QueryFpPower.
-func (mr *MockIBabylonClientMockRecorder) QueryFpPower(fpPubkeyHex, btcHeight any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryFpPower", reflect.TypeOf((*MockIBabylonClient)(nil).QueryFpPower), fpPubkeyHex, btcHeight)
-}
-
 // QueryMultiFpPower mocks base method.
 func (m *MockIBabylonClient) QueryMultiFpPower(fpPubkeyHexList []string, btcHeight uint32) (map[string]uint64, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Overview
Added basic Prometheus metrics to the finality gadget service. DevOps team can now monitor that blocks are being finalized and the service is healthy via the /metrics HTTP endpoint.
The implementation uses the existing Prometheus client dependency and exposes metrics on the same HTTP server as other endpoints.

## Metrics
- `finality_gadget_finalized_blocks_total` - Counter that increments each time blocks are finalized, allowing monitoring of block processing activity and rate
- `finality_gadget_finalized_blocks_total` - Counter that increments each time blocks are finalized, allowing monitoring of block processing activity and rate
- `finality_gadget_latest_finalized_block_height` - Gauge showing the height of the latest block confirmed as finalized by Babylon, enabling real-time finalization status monitoring
- `finality_gadget_fp_latest_block_voted` - Gauge tracking the latest block height each finality provider voted on, useful for detecting lagging or inactive FPs
- `finality_gadget_block_voters` - Gauge listing which finality providers voted for each specific block, enabling voting pattern analysis and participation tracking
- `finality_gadget_fp_voting_power_per_block` - Gauge showing each finality provider's voting power (in satoshis) at each block height, allowing monitoring of stake distribution and voting influence

Fixes #54