### PR TITLE
metric: track only missed blocks per FP

### DIFF
--- a/finalitygadget/finalitygadget.go
+++ b/finalitygadget/finalitygadget.go
@@ -147,6 +147,9 @@ func NewFinalityGadget(cfg *config.Config, db db.IDatabaseHandler, logger *zap.L
  *   - get all FPs that voted this L2 block with the same height and hash
  *   - calculate voted voting power
  *   - check if the voted voting power is more than 2/3 of the total voting power
+ *
+ * TODO: This query function should not track metrics. Callers should handle metrics tracking
+ * by calling trackFinalityProviderMetrics() when appropriate for their use case.
  */
 func (fg *FinalityGadget) QueryIsBlockBabylonFinalizedFromBabylon(block *types.Block) (bool, error) {
 	if block == nil {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -19,11 +19,11 @@ var (
 		Help: "Latest block height that each finality provider voted on",
 	}, []string{"fp_pubkey"})
 
-	// BlockVoters tracks which FPs voted for each block
-	BlockVoters = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "finality_gadget_block_voters",
-		Help: "List of finality providers who voted for each block",
-	}, []string{"block_height", "fp_pubkeys"})
+	// FpMissedBlocks tracks the total number of blocks missed by each FP
+	FpMissedBlocks = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "finality_gadget_fp_missed_blocks_total",
+		Help: "Total number of blocks missed by each finality provider",
+	}, []string{"fp_pubkey"})
 
 	// FpLatestVotingPower tracks each FP's voting power for the latest processed block
 	FpLatestVotingPower = promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -44,7 +44,7 @@ func Init(logger *zap.Logger) {
 	logger.Info("Prometheus metrics initialized",
 		zap.String("blocks_metric", "finality_gadget_finalized_blocks_total"),
 		zap.String("fp_voting_metric", "finality_gadget_fp_latest_block_voted"),
-		zap.String("block_voters_metric", "finality_gadget_block_voters"),
+		zap.String("fp_missed_blocks_metric", "finality_gadget_fp_missed_blocks_total"),
 		zap.String("fp_voting_power_metric", "finality_gadget_fp_latest_voting_power"),
 		zap.String("latest_finalized_metric", "finality_gadget_latest_finalized_block_height"))
 }


### PR DESCRIPTION
## Description

`finality_gadget_block_voters` blows prometheus. This metric needs to be removed and replaced with `finality_gadget_fp_missed_blocks_total`